### PR TITLE
Fix positioning bugs

### DIFF
--- a/lib/rendered-multi-select/version.rb
+++ b/lib/rendered-multi-select/version.rb
@@ -1,3 +1,3 @@
 module RenderedMultiSelect
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/lib/rendered-multi-select/version.rb
+++ b/lib/rendered-multi-select/version.rb
@@ -1,3 +1,3 @@
 module RenderedMultiSelect
-  VERSION = "1.1.3"
+  VERSION = "1.1.3".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rendered-multi-select",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Javascript control for selecting multiple elements (like tags) that can be rendered server-side.",
   "main": "vendor/assets/javascripts/rendered-multi-select.coffee",
   "directories": {

--- a/vendor/assets/javascripts/rendered-multi-select.coffee
+++ b/vendor/assets/javascripts/rendered-multi-select.coffee
@@ -80,6 +80,7 @@ class RenderedMultiSelect
 
   showResultMenu: ->
     return @resultMenu.show() unless @element.attr("data-fixed-menu") == "true"
+    return if @inputContainer.is(":hidden")
 
     winHeight = @win.height()
     inputTop  = @inputContainer.offset().top
@@ -92,8 +93,10 @@ class RenderedMultiSelect
 
     if winHeight / 2 < inputTop - scrollTop
       rules.bottom = winHeight - inputTop + scrollTop
+      rules.top = ""
     else
       rules.top = inputTop - scrollTop + @inputContainer.height()
+      rules.bottom = ""
 
     @resultMenu.css(rules)
     @body.css(overflow: 'hidden')


### PR DESCRIPTION
We shouldn't show the menu if the input container is hidden, and we should only have a top or a bottom -- never both.